### PR TITLE
UserList构造器继承EventEmitter问题

### DIFF
--- a/nodejs/basic.md
+++ b/nodejs/basic.md
@@ -878,7 +878,9 @@ events模块的作用，还表示在其他模块可以继承这个模块，因�
 var util = require("util");
 var EventEmitter = require("events").EventEmitter;
 
-function UserList (){}
+function UserList (){
+    EventEmitter.call(this);
+}
 
 util.inherits(UserList, EventEmitter);
 


### PR DESCRIPTION
初始化UserList时，需要使用构造器绑定，以调用到EventEmitter构造器中的方法。
