### PR TITLE
typeof 示例代码中的正误对比

### DIFF
--- a/grammar/basic.md
+++ b/grammar/basic.md
@@ -710,7 +710,7 @@ if (v){
 // ReferenceError: v is not defined
 
 // 正确的写法
-if (typeof v === "undefined"){
+if (typeof v !== "undefined"){
 	// ...
 }
 


### PR DESCRIPTION
虽然为了演示 typeof 的作用而省略了 if 块内的语句，但此处的正、误两个示例，其意图正好相反，不知会否给某些读者造成误会。此处修改假设代码的意图为“如果v已定义”。
