### PR TITLE
修改一些笔误

### DIFF
--- a/grammar/function.md
+++ b/grammar/function.md
@@ -327,7 +327,7 @@ function f() {/*
   多行注释
 */}
 
-multiline(f.toString())
+multiline(f);
 // " 这是一个
 //   多行注释"
 ```
@@ -847,7 +847,7 @@ function Person(name) {
   };
 }
 
-var p1 = person('张三');
+var p1 = Person('张三');
 p1.setAge(25);
 p1.getAge() // 25
 ```


### PR DESCRIPTION
- 调用 multiline 函数时，将参数从 f.toString() 改为 f。
- 将 person(‘张三’) 改为 Person(‘张三’)。
