### PR TITLE
document.links will not return link elements with href attributes. Ac…

### DIFF
--- a/dom/document.md
+++ b/dom/document.md
@@ -64,7 +64,7 @@ document.body === document.querySelector('body') // true
 
 ### document.links，document.forms，document.images，document.embeds
 
-`document.links`属性返回当前文档所有的`a`及`area`元素。
+`document.links`属性返回当前文档所有设定了`href`属性的`a`及`area`元素。
 
 `document.forms`属性返回页面中所有表单元素`form`。
 

--- a/dom/document.md
+++ b/dom/document.md
@@ -64,7 +64,7 @@ document.body === document.querySelector('body') // true
 
 ### document.links，document.forms，document.images，document.embeds
 
-`document.links`属性返回当前文档所有的`a`元素，或者说返回具有`href`属性的元素。
+`document.links`属性返回当前文档所有的`a`及`area`元素。
 
 `document.forms`属性返回页面中所有表单元素`form`。
 

--- a/dom/document.md
+++ b/dom/document.md
@@ -311,10 +311,10 @@ var interval = setInterval(function() {
 ```html
 <iframe id="editor" src="about:blank"></iframe>
 <script>
-onLoad(function () {
+!(function () {
   var editor = document.getElementById('editor');
   editor.contentDocument.designMode = 'on';
-});
+})();
 </script>
 ```
 


### PR DESCRIPTION
document.links 并不是返回所有具有'href'属性的元素，比如link元素则不会返回。从MDN上查询获知会返回a及area元素。所以，修改了一下此处的描述。

![qq 20161128145103](https://cloud.githubusercontent.com/assets/4190959/20658935/50833920-b57b-11e6-8bf9-9d3754398d1a.png)

参考链接 [https://developer.mozilla.org/en-US/docs/Web/API/Document/links]