### PR TITLE
修改

### DIFF
--- a/bom/ajax.md
+++ b/bom/ajax.md
@@ -861,7 +861,7 @@ Ajax操作所用的`XMLHttpRequest`对象，已经有十多年的历史，它的
 下面的代码检查浏览器是否部署了Fetch API。
 
 ```javascript
-if (fetch in window){
+if ("fetch" in window){
   // 支持
 } else {
   // 不支持


### PR DESCRIPTION
阮哥，in 的用法中前面一定要是字符串，并且是显式字符串不能直接裸奔的 例如这样 fetch in window ，是不行的。您写的例子我想是可以运行的那种例子并不是举个例子而已，所以正确的写法应该是 "fetch" in window，因为window只是这个对象的引用所以是不用添加字符串的。