### PR TITLE
修改mutationobserver的options参数

### DIFF
--- a/dom/mutationobserver.md
+++ b/dom/mutationobserver.md
@@ -62,15 +62,15 @@ observer.observe(article, options);
 
 观察器所能观察的 DOM 变动类型（即上面代码的`options`对象），有以下几种。
 
-- **childList**：子节点的变动。
+- **childList**：子节点的变动（指新增，删除或者更改）。
 - **attributes**：属性的变动。
 - **characterData**：节点内容或节点文本的变动。
-- **subtree**：所有后代节点的变动。
 
-想要观察哪一种变动类型，就在`option`对象中指定它的值为`true`。需要注意的是，如果设置观察`subtree`的变动，必须同时指定`childList`、`attributes`和`characterData`中的一种或多种。
+想要观察哪一种变动类型，就在`option`对象中指定它的值为`true`。需要注意的是，必须同时指定`childList`、`attributes`和`characterData`中的一种或多种，若未均指定将报错。
 
 除了变动类型，`options`对象还可以设定以下属性：
 
+- `subtree`：布尔值，表示是否将该观察器应用于该节点的所有后代节点。
 - `attributeOldValue`：布尔值，表示观察`attributes`变动时，是否需要记录变动前的属性值。
 - `characterDataOldValue`：布尔值，表示观察`characterData`变动时，是否需要记录变动前的值。
 - `attributeFilter`：数组，表示需要观察的特定属性（比如`['class','src']`）。


### PR DESCRIPTION
我认为这里的`subtree`应该放在除变动类型之外的配置属性里。
这是[MDN](https://developer.mozilla.org/zh-CN/docs/Web/API/MutationObserver)上的解释：
![image](https://user-images.githubusercontent.com/25007676/39998196-f12f635a-57b7-11e8-816d-1ce9d81a0cca.png)
我自己测试的代码：
![image](https://user-images.githubusercontent.com/25007676/39998375-7c01a754-57b8-11e8-97ff-0215195a75fd.png)

![image](https://user-images.githubusercontent.com/25007676/39998355-691212fa-57b8-11e8-8b51-a27372909df3.png)
可以看出subtree的作用应该是决定是否将观察器应用至该节点的所有子节点，而不是定义一种观察的变动类型。
同时给childList添加了一点解释，感觉这样更好理解。