### PR TITLE
docs(express): update optional params id to who

### DIFF
--- a/nodejs/express.md
+++ b/nodejs/express.md
@@ -333,7 +333,7 @@ app.get("/hello/:who", function(req, res) {
 {% highlight javascript %}
 
 app.get('/hello/:who?',function(req,res) {
-	if(req.params.id) {
+	if(req.params.who) {
     	res.end("Hello, " + req.params.who + ".");
 	}
     else {


### PR DESCRIPTION
发现 URL 中并没有用到 id 这个参数, 依旧是使用 who 这个参数么

 调整 req.params 使用的参数值从 id 改为 who